### PR TITLE
Add pattern matching to input files

### DIFF
--- a/entrypoint
+++ b/entrypoint
@@ -13,7 +13,15 @@ repository=${INPUT_REPOSITORY?Please specify a repository}
 
 # "files" array:
 if [ -n "$INPUT_FILES" ]; then
-    IFS=' ' read -r -a files <<< "$INPUT_FILES"
+    IFS=' ' read -r -a input_files <<<"$INPUT_FILES"
+
+    # Parse pattern matching in input files
+    files=()
+    for input_file in "${input_files[@]}"; do
+        for line in $(compgen -G "${input_file}"); do
+            files+=(line)
+        done
+    done
 else
     # Use all debs in current directory
     files=(*.deb)

--- a/entrypoint
+++ b/entrypoint
@@ -19,7 +19,7 @@ if [ -n "$INPUT_FILES" ]; then
     files=()
     for input_file in "${input_files[@]}"; do
         for line in $(compgen -G "${input_file}"); do
-            files+=(line)
+            files+=(${line})
         done
     done
 else


### PR DESCRIPTION
Closes #3

Update: this has been tested with a single `.dsc` file match. Basic testing of the concept suggests that this should scale properly.